### PR TITLE
Optimized, hosted GDS Viewer

### DIFF
--- a/.github/workflows/gds.yaml
+++ b/.github/workflows/gds.yaml
@@ -137,7 +137,7 @@ jobs:
     - name: populate viewer cache
       uses: actions/cache@v3
       with:
-        path: viewer
+        path: 'tinytapeout.gds.gltf'
         key: ${{ runner.os }}-viewer-${{ github.run_id }}
 
   artifact:
@@ -187,7 +187,7 @@ jobs:
     - name: restore viewer cache
       uses: actions/cache@v3
       with:
-        path: viewer
+        path: 'tinytapeout.gds.gltf'
         key: ${{ runner.os }}-viewer-${{ github.run_id }}
     - name: generate redirect to viewer
       run: |
@@ -202,7 +202,7 @@ jobs:
           </head>
           <body>
             <script>
-              location.href = "https://gds-viewer.tinytapeout.com/?model=" + encodeURIComponent(location.href + '/tinytapeout.gltf');
+              location.href = "https://gds-viewer.tinytapeout.com/?model=" + encodeURIComponent(location.href + '/tinytapeout.gds.gltf');
             </script>
           </body>
           </html>
@@ -229,5 +229,5 @@ jobs:
         # layout
         ![svg]($PAGE_URL/gds_render.svg)
         # viewer
-        [open preview](https://gds-viewer.tinytapeout.com/?model=$PAGE_URL/tinytapeout.gltf)
+        [open preview](https://gds-viewer.tinytapeout.com/?model=$PAGE_URL/tinytapeout.gds.gltf)
         EOF

--- a/.github/workflows/gds.yaml
+++ b/.github/workflows/gds.yaml
@@ -117,12 +117,6 @@ jobs:
       with:
         repository: mbalestrini/GDS2glTF
 
-    - name: checkout tinytapeout_gds_viewer repo
-      uses: actions/checkout@v3
-      with:
-        repository: mbalestrini/tinytapeout_gds_viewer
-        path: viewer
-
     - name: setup python
       uses: actions/setup-python@v4
       with:
@@ -139,7 +133,6 @@ jobs:
         python -m pip install numpy gdspy triangle pygltflib
         cp runs/wokwi/results/final/gds/*.gds tinytapeout.gds
         python3 gds2gltf.py tinytapeout.gds
-        cp tinytapeout.gds.gltf viewer/
 
     - name: populate viewer cache
       uses: actions/cache@v3
@@ -199,11 +192,20 @@ jobs:
     - name: generate redirect to viewer
       run: |
         cat << EOF >> index.html
-            <!DOCTYPE html>
-            <meta charset="utf-8">
-            <title>Redirecting to viewer</title>
-            <meta http-equiv="refresh" content="0; URL=viewer/tinytapeout.html">
-            <link rel="canonical" href="viewer/tinytapeout.html">
+          <!DOCTYPE html>
+          <html lang="en">
+          <head>
+            <meta charset="UTF-8">
+            <meta http-equiv="X-UA-Compatible" content="IE=edge">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <title>Redirecting to GDS Viewer...</title>
+          </head>
+          <body>
+            <script>
+              location.href = "https://gds-viewer.tinytapeout.com/?model=" + encodeURIComponent(location.href + '/tinytapeout.gltf');
+            </script>
+          </body>
+          </html>
         EOF
     - name: Setup Pages
       uses: actions/configure-pages@v2
@@ -227,5 +229,5 @@ jobs:
         # layout
         ![svg]($PAGE_URL/gds_render.svg)
         # viewer
-        [open preview]($PAGE_URL/viewer/tinytapeout.html)
+        [open preview](https://gds-viewer.tinytapeout.com/?model=$PAGE_URL/tinytapeout.gltf)
         EOF

--- a/info.yaml
+++ b/info.yaml
@@ -1,7 +1,7 @@
 --- 
 # TinyTapeout project information
 project:
-  wokwi_id:    0        # If using wokwi, set this to your project's ID
+  wokwi_id:    339800239192932947        # If using wokwi, set this to your project's ID
 #  source_files:        # If using an HDL, set wokwi_id as 0 and uncomment and list your source files here. Source files must be in ./src
 #    - counter.v
 #    - decoder.v


### PR DESCRIPTION
Notes:

1. To fully test it, we first name a CNAME from `gds-viewer.tinytapeout.com` to `tinytapeout.github.io`.
2. After merging this, make sure to set `wokwi_id` to 0 again (I set it just so I could test the complete workflow)