### PR TITLE
Update python version in gds and docs actions

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.7'
+        python-version: '3.10'
     - run: pip install requests PyYAML
 
     # fetch the Verilog from Wokwi API

--- a/.github/workflows/gds.yaml
+++ b/.github/workflows/gds.yaml
@@ -33,7 +33,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.7'
+        python-version: '3.10'
     - run: pip install requests PyYAML
 
     # fetch the Verilog from Wokwi API

--- a/info.yaml
+++ b/info.yaml
@@ -1,7 +1,7 @@
 --- 
 # TinyTapeout project information
 project:
-  wokwi_id:    0        # If using wokwi, set this to your project's ID
+  wokwi_id:    347130909553590866        # If using wokwi, set this to your project's ID
 #  source_files:        # If using an HDL, set wokwi_id as 0 and uncomment and list your source files here. Source files must be in ./src
 #    - counter.v
 #    - decoder.v

--- a/info.yaml
+++ b/info.yaml
@@ -43,3 +43,4 @@ documentation:
     - segment f
     - segment g
     - none
+

--- a/info.yaml
+++ b/info.yaml
@@ -1,7 +1,7 @@
 --- 
 # TinyTapeout project information
 project:
-  wokwi_id:    347497504164545108        # If using wokwi, set this to your project's ID
+  wokwi_id:    0        # If using wokwi, set this to your project's ID
 #  source_files:        # If using an HDL, set wokwi_id as 0 and uncomment and list your source files here. Source files must be in ./src
 #    - counter.v
 #    - decoder.v
@@ -14,17 +14,17 @@ project:
 #
 # This info will be automatically collected and used to make a datasheet for the chip.
 documentation: 
-  author:       "test"      # Your name
-  discord:      "test"      # Your discord handle
-  title:        "test"      # Project title
-  description:  "test"      # Short description of what your project does
-  how_it_works: "test"      # Longer description of how the project works
-  how_to_test:  "test"      # Instructions on how someone could test your project, include things like what buttons do what and how to set the clock if needed
-  external_hw:  "test"      # Describe any external hardware needed
+  author:       ""      # Your name
+  discord:      ""      # Your discord handle
+  title:        ""      # Project title
+  description:  ""      # Short description of what your project does
+  how_it_works: ""      # Longer description of how the project works
+  how_to_test:  ""      # Instructions on how someone could test your project, include things like what buttons do what and how to set the clock if needed
+  external_hw:  ""      # Describe any external hardware needed
   language:     "wokwi" # other examples include Verilog, Amaranth, VHDL, etc
-  doc_link:     "test"      # URL to longer form documentation, eg the README.md in your repository
+  doc_link:     ""      # URL to longer form documentation, eg the README.md in your repository
   clock_hz:     0       # Clock frequency in Hz (if required)
-  picture:      "test"      # relative path to a picture in your repository
+  picture:      ""      # relative path to a picture in your repository
   inputs:               # a description of what the inputs do
     - clock
     - reset
@@ -43,4 +43,3 @@ documentation:
     - segment f
     - segment g
     - none
-

--- a/info.yaml
+++ b/info.yaml
@@ -14,17 +14,17 @@ project:
 #
 # This info will be automatically collected and used to make a datasheet for the chip.
 documentation: 
-  author:       ""      # Your name
-  discord:      ""      # Your discord handle
-  title:        ""      # Project title
-  description:  ""      # Short description of what your project does
-  how_it_works: ""      # Longer description of how the project works
-  how_to_test:  ""      # Instructions on how someone could test your project, include things like what buttons do what and how to set the clock if needed
-  external_hw:  ""      # Describe any external hardware needed
+  author:       "test"      # Your name
+  discord:      "test"      # Your discord handle
+  title:        "test"      # Project title
+  description:  "test"      # Short description of what your project does
+  how_it_works: "test"      # Longer description of how the project works
+  how_to_test:  "test"      # Instructions on how someone could test your project, include things like what buttons do what and how to set the clock if needed
+  external_hw:  "test"      # Describe any external hardware needed
   language:     "wokwi" # other examples include Verilog, Amaranth, VHDL, etc
-  doc_link:     ""      # URL to longer form documentation, eg the README.md in your repository
+  doc_link:     "test"      # URL to longer form documentation, eg the README.md in your repository
   clock_hz:     0       # Clock frequency in Hz (if required)
-  picture:      ""      # relative path to a picture in your repository
+  picture:      "test"      # relative path to a picture in your repository
   inputs:               # a description of what the inputs do
     - clock
     - reset

--- a/info.yaml
+++ b/info.yaml
@@ -1,7 +1,7 @@
 --- 
 # TinyTapeout project information
 project:
-  wokwi_id:    347130909553590866        # If using wokwi, set this to your project's ID
+  wokwi_id:    347497504164545108        # If using wokwi, set this to your project's ID
 #  source_files:        # If using an HDL, set wokwi_id as 0 and uncomment and list your source files here. Source files must be in ./src
 #    - counter.v
 #    - decoder.v


### PR DESCRIPTION
Updating python version appears to fix the error of python version 3.7.7 not being available when running the GitHub actions are run with a VM using Linux version 22.04

