### PR TITLE
fix constants in dffsr_cell

### DIFF
--- a/src/cells.v
+++ b/src/cells.v
@@ -93,9 +93,9 @@ module dffsr_cell (
 
     always @(posedge clk or posedge s or posedge r) begin
         if (r)
-            q <= '0;
+            q <= 0;
         else if (s)
-            q <= '1;
+            q <= 1;
         else
             q <= d;
     end


### PR DESCRIPTION
iverilog complains about the current syntax:

```
src/cells.v:96: warning: Using SystemVerilog 'N bit vector.  Use at least -g2005-sv to remove this warning.
src/cells.v:98: warning: Using SystemVerilog 'N bit vector.  Use at least -g2005-sv to remove this warning.
```